### PR TITLE
[Bug/strikeCheckButton] check button 연타 시 종료

### DIFF
--- a/app/src/main/java/com/example/aganada/learn/LearnFragment.kt
+++ b/app/src/main/java/com/example/aganada/learn/LearnFragment.kt
@@ -60,6 +60,7 @@ class LearnFragment : Fragment() {
             checkButton.setOnClickListener {
                 Log.v("LearnFragment", "Check button clicked.")
                 this@LearnFragment.viewModel.recognizeText(wordView.pathSet)
+                wordView.clearPathSet()
             }
 
             cameraButton.setOnClickListener {

--- a/app/src/main/java/com/example/aganada/learn/LearnFragmentViewModel.kt
+++ b/app/src/main/java/com/example/aganada/learn/LearnFragmentViewModel.kt
@@ -97,6 +97,9 @@ class LearnFragmentViewModel: ViewModel() {
     }
 
     fun recognizeText(set: Collection<WordView.PathData>) {
+        if (set.isEmpty()) {
+            return
+        }
         if (checkResult.value?.working == true) {
             return
         }

--- a/app/src/main/java/com/example/aganada/test/TestFragment.kt
+++ b/app/src/main/java/com/example/aganada/test/TestFragment.kt
@@ -63,6 +63,7 @@ class TestFragment : Fragment() {
             redoButton.setOnClickListener { wordView.reDo() }
             checkButton.setOnClickListener {
                 this@TestFragment.viewModel.recognizeText(wordView.pathSet)
+                wordView.clearPathSet()
             }
             nextButton.setOnClickListener { this@TestFragment.viewModel.getNext() }
             prevButton.setOnClickListener { this@TestFragment.viewModel.getPrev() }

--- a/app/src/main/java/com/example/aganada/test/TestFragmentViewModel.kt
+++ b/app/src/main/java/com/example/aganada/test/TestFragmentViewModel.kt
@@ -89,6 +89,9 @@ class TestFragmentViewModel: ViewModel() {
     }
 
     fun recognizeText(set: Collection<WordView.PathData>) {
+        if (set.isEmpty()) {
+            return
+        }
         if (checkResult.value?.working == true) {
             return
         }

--- a/app/src/main/java/com/example/aganada/views/WordView.kt
+++ b/app/src/main/java/com/example/aganada/views/WordView.kt
@@ -84,6 +84,10 @@ class WordView @JvmOverloads constructor(
         invalidate()
     }
 
+    fun clearPathSet() {
+        pathSet.clear()
+    }
+
     fun clear() {
         drawOpStack.clear()
         undoStack.clear()


### PR DESCRIPTION
아무것도 쓰지 않고 check button을 실행했을 때 그 다음부터는 잘 쓰고 check button을 눌러도 작동하지 않습니다.
Learn 에서는 틀린 경우 연타 시 종료됩니다.

다음 두 가지 hack을 추가했습니다.
1. Empty set 에 대해 recognizeText 수행하지 않음
2. recognizeText 수행 후 wordView 의 pathSet 을 clear

연타를 해도 첫 recognizeText 수행 후 pathSet 이 clear 되어, 그 다음 클릭부터는 recognizeText 를 수행하지 않습니다.
화면에 글자가 남아있게 하는 편이 나을 것 같아 pathSet 만 clear 했습니다.
