### PR TITLE
[Feature/cameraRotate] Landscape 방향에 따른 다른 orientation 범위 적용

### DIFF
--- a/app/src/main/java/com/example/aganada/camera/CameraXActivity.kt
+++ b/app/src/main/java/com/example/aganada/camera/CameraXActivity.kt
@@ -107,17 +107,17 @@ class CameraXActivity :
         val orientationEventListener = object : OrientationEventListener(this as Context) {
             override fun onOrientationChanged(orientation : Int) {
                 // Monitors orientation values to determine the target rotation value
-                val winM = getSystemService(Context.WINDOW_SERVICE) as WindowManager
-                val rot : Int = when (winM.defaultDisplay.rotation) {
+                val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+                val rot : Int = when (windowManager.defaultDisplay.rotation) {
                     Surface.ROTATION_90 -> {
                         when (orientation) {
-                            in 45..134 -> Surface.ROTATION_270
+                            in 46..134 -> Surface.ROTATION_270
                             else -> Surface.ROTATION_90
                         }
                     }
                     else -> {
                         when (orientation) {
-                            in 225..314 -> Surface.ROTATION_90
+                            in 226..314 -> Surface.ROTATION_90
                             else -> Surface.ROTATION_270
                         }
                     }

--- a/app/src/main/java/com/example/aganada/camera/CameraXActivity.kt
+++ b/app/src/main/java/com/example/aganada/camera/CameraXActivity.kt
@@ -24,8 +24,6 @@ import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
-import android.view.MotionEvent
-import android.view.View
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.CompoundButton
@@ -56,8 +54,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import android.graphics.Bitmap
-import android.view.OrientationEventListener
-import android.view.Surface
+import android.view.*
 
 /** Live preview demo app for ML Kit APIs using CameraX. */
 @KeepName
@@ -110,11 +107,20 @@ class CameraXActivity :
         val orientationEventListener = object : OrientationEventListener(this as Context) {
             override fun onOrientationChanged(orientation : Int) {
                 // Monitors orientation values to determine the target rotation value
-                val rot : Int = when (orientation) {
-                    in 45..134 -> Surface.ROTATION_270
-                    //in 135..224 -> Surface.ROTATION_180
-                    else -> Surface.ROTATION_90
-                    //else -> Surface.ROTATION_0
+                val winM = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+                val rot : Int = when (winM.defaultDisplay.rotation) {
+                    Surface.ROTATION_90 -> {
+                        when (orientation) {
+                            in 45..134 -> Surface.ROTATION_270
+                            else -> Surface.ROTATION_90
+                        }
+                    }
+                    else -> {
+                        when (orientation) {
+                            in 225..314 -> Surface.ROTATION_90
+                            else -> Surface.ROTATION_270
+                        }
+                    }
                 }
                 if (captureUseCase != null && analysisUseCase != null){
                     captureUseCase!!.targetRotation = rot


### PR DESCRIPTION
Landscape 방향에 따라 다른 orientation 을 적용합니다.

예컨데, 기기를 수직으로 들고 있는 orientation 에서는 두 가지 Landscape방향에서 모두 바르게 서 보여야 하는데,
Landscape 에 따라 달라지지 않는다면 이는 한 Landscape 에서는 잘 보이지만 다른 Landscape 에서는 거꾸로 보입니다.

이를 해결하기 위해 Landscape 의 방향을 알아온 뒤 다른 범위를 적용하여 카메라의 Rotation 을 바꿔줍니다.